### PR TITLE
added module Reinforcement() to reinforce the holes in the box

### DIFF
--- a/MarioBox.scad
+++ b/MarioBox.scad
@@ -46,8 +46,17 @@ module Cutout_BoltHead(size, depth) {
 }
 
 module AllModels() {
-    rotate([0,0,90]) import("box.stl", convexity=10);
+    union(){
+        rotate([0,0,90]) import("Box.stl", convexity=10);
+        Reinforcement();
+    }
     translate([clipLocX,clipLocY,clipLocZ]) clip(cubeDimsX,cubeDimsY,cubeDimsZ);
+    
+}
+
+module Reinforcement(){
+    translate([-3,-86,37]) 
+    cube([3,69,50]);
 }
 
 


### PR DESCRIPTION
i created some reinforcements and learned the basics of openscad.

the reinforcements are not perfect and stick int o the retractions in the corners a little bit, but i wanted to keep it to one `cube()`

i dont know why github thinks i replaced the whole file with the same content :/

also: the `box.stl` didnt work for me, had to re-download and convert the `.step` file...